### PR TITLE
Fix deployment by not specifying image_web_version

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -108,7 +108,6 @@ objects:
         object_storage_s3_secret: test-s3
         image: "${IMAGE}"
         image_version: "${IMAGE_TAG}"
-        image_web_version: latest
       EOF
       do
         echo "Trying kubectl apply again"


### PR DESCRIPTION
Since we have no webserver snippets, and the image_web_version

must be identical to image_version anyway.