### PR TITLE
less wgets, more curl

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -33,7 +33,7 @@ objects:
       export PATH=${PATH}:/tmp/bin
       mkdir /tmp/bin
       cd /tmp/bin
-      wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+      curl -O https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
       mv jq-linux64 jq
       chmod +x jq
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -33,7 +33,7 @@ objects:
       export PATH=${PATH}:/tmp/bin
       mkdir /tmp/bin
       cd /tmp/bin
-      wget wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+      wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
       mv jq-linux64 jq
       chmod +x jq
 


### PR DESCRIPTION
Hi

I noticed error because of duplicate `wget` :

+ cd /tmp/bin
+ wget wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
--2023-06-26 11:01:40--  http://wget/
Resolving wget (wget)... failed: Name or service not known.
wget: unable to resolve host address 'wget'

So I made PR to remove one, but its better not to use wget at all in scripts or Dockerfiles as its not installed by default. So I made second commit to change to `curl -O`.  Hope that is OK.

Thank you.