### PR TITLE
rename cr-generator to app

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -157,7 +157,7 @@ objects:
     testing:
       iqePlugin: content-sources
     deployments:
-    - name: cr-generator
+    - name: app
       podSpec:
         # dummy container
         image: "quay.io/openshift/origin-cli:latest"


### PR DESCRIPTION
I am renaming our 'cr-generator' deployment to 'app'. This causes it to be called 'content-sources-pulp-app' instead of 'content-sources-pulp-cr-generator'. Then the service account configured inside it is also called 'content-sources-pulp-app'.