### PR TITLE
Update pr_check, include HMS apps on deploy

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
-# --------------------------------------------
-# Options that must be configured by app owner
-# --------------------------------------------
 APP_NAME="content-sources"  # name of app-sre "application" folder this component lives in
 COMPONENT_NAME="content-sources-pulp"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 IMAGE="quay.io/cloudservices/pulp-rpm-ubi"
+
+# be explicit about what to build
+DOCKERFILE=Dockerfile
+
+# Include all impacted HMS apps for deployment
+EXTRA_DEPLOY_ARGS="provisioning sources image-builder-crc"
 
 IQE_PLUGINS="content-sources"
 IQE_MARKER_EXPRESSION="api"
@@ -13,7 +16,7 @@ IQE_FILTER_EXPRESSION=""
 IQE_CJI_TIMEOUT="30m"
 
 # Install bonfire repo/initialize
-CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
+CICD_URL=https://raw.githubusercontent.com/RedHatInsights/cicd-tools/master
 curl -s $CICD_URL/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
 source $CICD_ROOT/build.sh


### PR DESCRIPTION
After discussion about impacts of changes to the clowdapp templates in this repo, @dkliban and I agreed to include more apps in the bonfire deployment in pr-check.

~I'm also working with @dkliban on getting pr-checks to start running on jenkins.~

Refs [HMS-2516](https://issues.redhat.com/browse/HMS-2516)

## Passing check will depend on
https://github.com/redhat-openshift-ecosystem/community-operators-prod/pull/3190